### PR TITLE
Decouple from state commitments

### DIFF
--- a/src/lotion-state-machine.ts
+++ b/src/lotion-state-machine.ts
@@ -24,7 +24,7 @@ export interface StateMachine {
   check?(action)
   query(query?)
   context?()
-  commit(): string | Buffer | Promise<string | Buffer>
+  commit()
 }
 
 export type TransactionHandler = (state, tx, context?) => any
@@ -37,7 +37,7 @@ export interface Application {
   useTx(txHandler: TransactionHandler)
   useBlock(blockHandler: BlockHandler)
   useInitializer(initializer: Initializer)
-  compile?(): StateMachine
+  compile?(state: object): StateMachine
 }
 
 export interface BaseApplicationConfig {
@@ -114,13 +114,14 @@ function LotionStateMachine(opts: BaseApplicationConfig): Application {
     useInitializer(initializer) {
       initializers.push(initializer)
     },
-    compile(): StateMachine {
+    compile(appState = {}): StateMachine {
       if (routes != null) {
         let router = Router(routes)
         appMethods.use(router)
       }
 
-      let appState = opts.initialState || {}
+      let initialState = opts.initialState || {}
+      Object.assign(appState, initialState)
       let mempoolState = muta(appState)
 
       let nextState, nextValidators, nextContext

--- a/src/lotion-state-machine.ts
+++ b/src/lotion-state-machine.ts
@@ -224,10 +224,6 @@ function LotionStateMachine(opts: BaseApplicationConfig): Application {
 
           mempoolState = muta(appState)
           mempoolValidators = muta(chainValidators)
-
-          return createHash('sha256')
-            .update(djson.stringify(appState))
-            .digest('hex')
         },
 
         check(tx) {

--- a/test/counter.js
+++ b/test/counter.js
@@ -37,11 +37,7 @@ test('counter app', t => {
 
   lsm.transition({ type: 'begin-block', data: { time: 200 } })
   lsm.transition({ type: 'block', data: {} })
-  hash = lsm.commit()
-  t.equal(
-    hash,
-    '8353f3a8b718e3ac9661f9bee86e0b5cfe0115b797101c40cf002e974800e148'
-  )
+  lsm.commit()
 
   state = lsm.query()
   t.equal(state.count, 3)

--- a/test/state-machine.js
+++ b/test/state-machine.js
@@ -154,7 +154,7 @@ test('check has side effects on mempool validators', (t) => {
 
 test('check does not have side effects on committed state', (t) => {
   let state = {}
-  let app = LotionStateMachine({ initialState: state })
+  let app = LotionStateMachine({})
 
   let expected
   app.useTx((state, tx, ctx) => {
@@ -162,7 +162,7 @@ test('check does not have side effects on committed state', (t) => {
     state.x += 1
   })
 
-  let lsm = app.compile()
+  let lsm = app.compile(state)
   lsm.initialize({ x: 0 }, {})
 
   expected = 0
@@ -181,7 +181,7 @@ test('check does not have side effects on committed state', (t) => {
 
 test('check does not have side effects on transition state', (t) => {
   let state = {}
-  let app = LotionStateMachine({ initialState: state })
+  let app = LotionStateMachine({})
 
   let expected
   app.useTx((state, tx, ctx) => {
@@ -189,7 +189,7 @@ test('check does not have side effects on transition state', (t) => {
     state.x += 1
   })
 
-  let lsm = app.compile()
+  let lsm = app.compile(state)
   lsm.initialize({ x: 0 }, {})
 
   expected = 0


### PR DESCRIPTION
- Don't compute hash of state in this package since that's complex enough to live outside
- Added optional `state` object argument to `compile` method, to create a state machine that references a specific object for state storage